### PR TITLE
Fix client.createInvite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -839,6 +839,7 @@ DCP.acceptInvite = function(NUL, callback) {
  * @arg {Number} input.max_age
  * @arg {Number} input.max_uses
  * @arg {Boolean} input.temporary
+ * @arg {Boolean} input.unique
  */
 DCP.createInvite = function(input, callback) {
 	var allowed = ["channelID", "max_age", "max_uses", "temporary", "unique"];

--- a/lib/index.js
+++ b/lib/index.js
@@ -841,9 +841,14 @@ DCP.acceptInvite = function(NUL, callback) {
  * @arg {Boolean} input.temporary
  */
 DCP.createInvite = function(input, callback) {
-	var payload, client = this;
+	var allowed = ["channelID", "max_age", "max_uses", "temporary", "unique"];
+	var payload = {};
 
-	this._req('post', Endpoints.CHANNEL(input.channelID) + "/invites", input, function(err, res) {
+	allowed.forEach(function(name) {
+		if (input[name]) payload[name] = input[name];
+	});
+
+	this._req('post', Endpoints.CHANNEL(payload.channelID) + "/invites", payload, function(err, res) {
 		handleResCB('Unable to create invite', err, res, callback);
 	});
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -833,31 +833,17 @@ DCP.acceptInvite = function(NUL, callback) {
 };
 
 /**
- * (Used to) Generate an invite URL for a channel.
- * @deprecated
+ * Generate an invite URL for a channel.
+ * @arg {Object} input
+ * @arg {Snowflake} input.channelID
+ * @arg {Number} input.max_age
+ * @arg {Number} input.max_uses
+ * @arg {Boolean} input.temporary
  */
 DCP.createInvite = function(input, callback) {
 	var payload, client = this;
 
-	payload = {
-		max_age: 0,
-		max_users: 0,
-		temporary: false
-	};
-
-	if ( Object.keys(input).length === 1 && input.channelID ) {
-		payload = {
-			validate: client.internals.lastInviteCode || null
-		};
-	}
-
-	for (var key in input) {
-		if (Object.keys(payload).indexOf(key) < 0) continue;
-		payload[key] = input[key];
-	}
-
-	this._req('post', Endpoints.CHANNEL(input.channelID) + "/invites", payload, function(err, res) {
-		try {client.internals.lastInviteCode = res.body.code;} catch(e) {}
+	this._req('post', Endpoints.CHANNEL(input.channelID) + "/invites", input, function(err, res) {
 		handleResCB('Unable to create invite', err, res, callback);
 	});
 };


### PR DESCRIPTION
Got client.createInvite working properly. Upon reading the API docs it turns out there's no need for the "lastInviteCode" jank that was previously going on. I stripped almost all the old code out and instead it now submits the input directly as the payload. Of course, it won't be "clean", but Discord's API doesn't care.

If you want a "cleaned" version, where there's no unused object properties going through to the final payload, let me know and I'll make another commit.