### PR TITLE
Reset voice_channel_id property of members when the voice channel they are in is deleted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1906,6 +1906,11 @@ function handleWSMessage(data, flags) {
 				delete(client.directMessages[_data.id]);
 				return delete(client._uIDToDM[_data.recipients[0].id]);
 			}
+			Object.keys(client.servers[_data.guild_id].members).forEach(function(m) {
+				if (client.servers[_data.guild_id].members[m].voice_channel_id == _data.id) {
+					client.servers[_data.guild_id].members[m].voice_channel_id = null;
+				}
+			});
 			emit(client, message, client.servers[_data.guild_id].channels[_data.id]);
 			delete(client.servers[_data.guild_id].channels[_data.id]);
 			return delete(client.channels[_data.id]);


### PR DESCRIPTION
When some members are in a voice channel and that voice channel is deleted, previously the voice_channel_id property of those members would stick around, despite them having left the channel. This change sets the voice_channel_id of all members in the now deleted channel to null.

Well, that's what my commit description says. I'm not *too* familiar with the internals of the lib, but this appears to work properly. Would you mind checking it over yourself before accepting this PR?