### PR TITLE
Fix heartbeating, resuming, disconnect errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ DCP.connect = function () {
  * Disconnect the WebSocket connection to Discord.
  */
 DCP.disconnect = function () {
-	if (this._ws) return this._ws.close(), log(this, "Manual disconnect called, websocket closed");
+	if (this._ws) return this._ws.close(1000, "Manual disconnect"), log(this, "Manual disconnect called, websocket closed");
 	return log(this, Discord.LogLevels.Warn, "Manual disconnect called with no WebSocket active, ignored");
 };
 
@@ -1749,26 +1749,41 @@ function handleWSMessage(data, flags) {
 			//Event dispatched - update our sequence number
 			client.internals.sequence = message.s;
 			break;
+		case 1:
+			//Heartbeat requested by Discord - send one immediately
+			send(client._ws, Payloads.HEARTBEAT(client));
+			break;
+		case 7:
+			//Reconnect requested by discord
+			clearTimeout(client.internals.heartbeat);
+			client._ws.close(1000, 'Reconnect requested by Discord');
+			break;
 		case 9:
-			//Disconnect after a Invalid Session
+			//Disconnect after an Invalid Session
 			//Disconnect the client if the client has received an invalid session id
-			delete client.internals.sequence;
-			delete client.internals.sessionID;
-			client._ws && client._ws.close(1e3, 'Received an invalid session id');
+			if(!message.d) {
+				delete(client.internals.sequence);
+				delete(client.internals.sessionID);
+				//Send new identify after 1-5 seconds, chosen randomly (per Gateway docs)
+				setTimeout(function() {
+					identifyOrResume(client);
+				}, Math.random()*4000+1000);
+			} else identifyOrResume(client);
+			
+			
 			break;
 		case 10:
 			//Start keep-alive interval
 			//Disconnect the client if no ping has been received
-			//in 15 seconds (I think that's a decent duration)
-			//Since v3 you the IDENTIFY/RESUME payload here.
+			//Since v3 you send the IDENTIFY/RESUME payload here.
 			identifyOrResume(client);
 			client.presenceStatus = 'online';
 			client.connected = true;
 
 			client._mainKeepAlive = setInterval(function() {
 				client.internals.heartbeat = setTimeout(function() {
-					client._ws && client._ws.close(1e3, 'No heartbeat received');
-				}, 15e3);
+					client._ws && client._ws.close(1001, "No heartbeat received");
+				}, _data.heartbeat_interval);
 				client.internals._lastHB = Date.now();
 				send(client._ws, Payloads.HEARTBEAT(client));
 			}, _data.heartbeat_interval);
@@ -2009,7 +2024,7 @@ function handleWSMessage(data, flags) {
 }
 function handleWSClose(code, data) {
 	var client = this;
-	var eMsg = Discord.Codes.WebSocket[code];
+	var eMsg = Discord.Codes.WebSocket[code] || data;
 
 	clearInterval(client._mainKeepAlive);
 	client.connected = false;
@@ -2691,7 +2706,9 @@ Discord.Codes.WebSocket = {
 	"4007": "Invalid Sequence Number",
 	"4008": "Rate Limited",
 	"4009": "Session Timeout",
-	"4010": "Invalid Shard"
+	"4010": "Invalid Shard",
+	"4011": "Sharding Required",
+	"4012": "Invalid Gateway Version"
 };
 Discord.Colors = {
 	DEFAULT: 0,
@@ -2933,9 +2950,9 @@ function Websocket(url, opts) {
 			return {
 				op: 6,
 				d: {
-					seq: client.internals.s,
 					token: client.internals.token,
-					session_id: client.internals.sessionID
+					session_id: client.internals.sessionID,
+					seq: client.internals.sequence
 				}
 			};
 		},

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,6 @@ Discord.Client = function DiscordClient(options) {
 		["_messageCacheLimit", typeof(options.messageCacheLimit) === 'number' ? options.messageCacheLimit : 50],
 	]);
 
-	this.presenceStatus = "offline";
 	this.connected = false;
 	this.inviteURL = null;
 	this.connect = this.connect.bind(this, options);
@@ -146,8 +145,7 @@ DCP.setPresence = function(input) {
 	var payload = Payloads.STATUS(input);
 	send(this._ws, payload);
 
-	if (payload.d.since === null) return void(this.presenceStatus = payload.d.status);
-	this.presenceStatus = payload.d.status;
+	this.presence = payload.d;
 };
 
 /**
@@ -1777,7 +1775,7 @@ function handleWSMessage(data, flags) {
 			//Disconnect the client if no ping has been received
 			//Since v3 you send the IDENTIFY/RESUME payload here.
 			identifyOrResume(client);
-			client.presenceStatus = 'online';
+			if(!client.presence) client.presence = { status: "online", since: Date.now() };
 			client.connected = true;
 
 			client._mainKeepAlive = setInterval(function() {
@@ -2028,7 +2026,6 @@ function handleWSClose(code, data) {
 
 	clearInterval(client._mainKeepAlive);
 	client.connected = false;
-	client.presenceStatus = "offline";
 	removeAllListeners(client._ws, 'message');
 
 	if ([1001, 1006].indexOf(code) > -1) return getGateway(client, client.internals.token);
@@ -2933,9 +2930,9 @@ function Websocket(url, opts) {
 				op: 2,
 				d: {
 					token: client.internals.token,
-					v: GATEWAY_VERSION,
 					compress: isNode && !!Zlib.inflateSync,
 					large_threshold: LARGE_THRESHOLD,
+					presence: client.presence,
 					properties: {
 						$os: isNode ? require('os').platform() : navigator.platform,
 						$browser:"discord.io",


### PR DESCRIPTION
* adds more error codes and correctly passes through all error messages to "disconnect" event (instead of just 40** ones)
* adds correct support for opcodes 1, 7, 9, 10 per Discord gateway docs
* fixes a typo preventing a successful Resume from ever happening
* lengthens heartbeat window to correct length - previously hard set to 15s, now set to value received by discord
* changes to client presence caching to support these changes - sends presence info with Identify payload

End result is an increase in stability and decrease in disconnect events in general, as "Invalid Session" and "No Heartbeat" are now handled properly as per Discord gateway docs - in both cases the client automatically attempts to reconnect and resume, meaning no missed Discord events and no 'disconnect' event needing handling.