### PR TITLE
Fix TypeScript error (partways) for DCP.editRole

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -280,7 +280,7 @@ declare type editRoleOpts = {
   name: string,
   hoist: boolean,
   permissions: permissions,
-  color: colors,
+  color: colors | number,
   mentionable: boolean,
   // I dont know what position is and it is unused in current code
   position: any


### PR DESCRIPTION
'color' can be a predefined colour, number, or hex-colour string. I couldn't implement that last one in TypeScript, but I added support for a number alongside a predefined colour.