### PR TITLE
Add permissions in editChannelPermissions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1008,8 +1008,8 @@ DCP.editChannelPermissions = function(input, callback) { //Will shrink this up l
 	channel = this.channels[ input.channelID ];
 	permissions = channel.permissions[pType][ID] || { allow: 0, deny: 0 };
 	allowed_values = [0, 4, 28].concat((channel.type === 'text' ?
-	[10, 11, 12, 13, 14, 15, 16, 17, 18] :
-	[20, 21, 22, 23, 24, 25] ));
+	[6, 10, 11, 12, 13, 14, 15, 16, 17, 18] :
+	[20, 21, 22, 23, 24, 25, 29] ));
 
 	//Take care of allow first
 	if (type(input.allow) === 'array') {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -97,7 +97,9 @@ declare interface permissions {
   GENERAL_MANAGE_ROLES?: boolean;
   GENERAL_MANAGE_NICKNAMES?: boolean;
   GENERAL_CHANGE_NICKNAME?: boolean;
+  GENERAL_MANAGE_WEBHOOKS?: boolean;
 
+  TEXT_ADD_REACTIONS?: boolean;
   TEXT_READ_MESSAGES?: boolean;
   TEXT_SEND_MESSAGES?: boolean;
   TEXT_SEND_TTS_MESSAGE?: boolean;


### PR DESCRIPTION
editChannelPermissions - Add GENERAL_MANAGE_WEBHOOKS & TEXT_ADD_REACTIONS in allowed_values
GENERAL_MANAGE_WEBHOOKS and TEXT_ADD_REACTIONS have been added to the permissions interface.