### PR TITLE
Fix nickname lookup in fixMessage function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -372,23 +372,25 @@ DCP.simulateTyping = function(channelID, callback) {
 /**
  * Replace Snowflakes with the names if applicable.
  * @arg {String} message - The message to fix.
+ * @arg {Snowflake|null} serverID - Optional, the ID of the message's server of origin, used for nickname lookup
  */
-DCP.fixMessage = function(message) {
-	var client = this;
-	return message.replace(/<@&(\d*)>|<@!(\d*)>|<@(\d*)>|<#(\d*)>/g, function(match, RID, NID, UID, CID) {
-		var k, i;
-		if (UID || CID) {
-			if (client.users[UID]) return "@" + client.users[UID].username;
-			if (client.channels[CID]) return "#" + client.channels[CID].name;
-		}
-		if (RID || NID) {
-			k = Object.keys(client.servers);
-			for (i=0; i<k.length; i++) {
-				if (client.servers[k[i]].roles[RID]) return "@" + client.servers[k[i]].roles[RID].name;
-				if (client.servers[k[i]].members[NID]) return "@" + client.servers[k[i]].members[NID].nick;
-			}
-		}
-	});
+DCP.fixMessage = function(message, serverID) {
+var client = this;
+return message.replace(/<@&(\d*)>|<@!(\d*)>|<@(\d*)>|<#(\d*)>/g, function(match, RID, NID, UID, CID) {
+    var k, i;
+    if (UID || CID) {
+	if (client.users[UID]) return "@" + client.users[UID].username;
+	if (client.channels[CID]) return "#" + client.channels[CID].name;
+    }
+    if (RID || NID) {
+	if (NID && client.servers[serverID]) return "@" + client.servers[serverID].members[NID].nick;
+	k = Object.keys(client.servers);
+	for (i=0; i<k.length; i++) {
+	    if (client.servers[k[i]].roles[RID]) return "@" + client.servers[k[i]].roles[RID].name;
+	    if (client.servers[k[i]].members[NID] && client.servers[k[i]].members[NID].nick) return "@" + client.servers[k[i]].members[NID].nick;
+	}
+    }
+});
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -375,22 +375,22 @@ DCP.simulateTyping = function(channelID, callback) {
  * @arg {Snowflake|null} serverID - Optional, the ID of the message's server of origin, used for nickname lookup
  */
 DCP.fixMessage = function(message, serverID) {
-var client = this;
-return message.replace(/<@&(\d*)>|<@!(\d*)>|<@(\d*)>|<#(\d*)>/g, function(match, RID, NID, UID, CID) {
-    var k, i;
-    if (UID || CID) {
-	if (client.users[UID]) return "@" + client.users[UID].username;
-	if (client.channels[CID]) return "#" + client.channels[CID].name;
-    }
-    if (RID || NID) {
-	if (NID && client.servers[serverID]) return "@" + client.servers[serverID].members[NID].nick;
-	k = Object.keys(client.servers);
-	for (i=0; i<k.length; i++) {
-	    if (client.servers[k[i]].roles[RID]) return "@" + client.servers[k[i]].roles[RID].name;
-	    if (client.servers[k[i]].members[NID] && client.servers[k[i]].members[NID].nick) return "@" + client.servers[k[i]].members[NID].nick;
-	}
-    }
-});
+    var client = this;
+    return message.replace(/<@&(\d*)>|<@!(\d*)>|<@(\d*)>|<#(\d*)>/g, function(match, RID, NID, UID, CID) {
+        var k, i;
+        if (UID || CID) {
+            if (client.users[UID]) return "@" + client.users[UID].username;
+            if (client.channels[CID]) return "#" + client.channels[CID].name;
+        }
+        if (RID || NID) {
+            if (NID && client.servers[serverID]) return "@" + client.servers[serverID].members[NID].nick;
+            k = Object.keys(client.servers);
+            for (i=0; i<k.length; i++) {
+                if (client.servers[k[i]].roles[RID]) return "@" + client.servers[k[i]].roles[RID].name;
+                if (client.servers[k[i]].members[NID] && client.servers[k[i]].members[NID].nick) return "@" + client.servers[k[i]].members[NID].nick;
+            }
+        }
+    });
 };
 
 /**


### PR DESCRIPTION
**Old behavior:** If the user being mentioned has a nickname, the fixMessage function loops through the servers until it finds one with that member, so if that user is in another server without a nickname and it comes up first, the `.nick` property will be `null` or `undefined`, resulting in the message saying `"@null"` or `"@undefined"`

**Now:** Adding an optional argument for the serverID so the correct nickname can be determined. If the server ID is not provided, the first server found in which the user has a nickname will be used. This avoids @null or @undefined results.