### PR TITLE
Fix max_age=0 in createInvite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -846,7 +846,7 @@ DCP.createInvite = function(input, callback) {
 	var payload = {};
 
 	allowed.forEach(function(name) {
-		if (input[name]) payload[name] = input[name];
+		if (input[name] !== undefined) payload[name] = input[name];
 	});
 
 	this._req('post', Endpoints.CHANNEL(payload.channelID) + "/invites", payload, function(err, res) {


### PR DESCRIPTION
Previously, if a parameter was a falsy value, it would have been ignored. Now the parameter is only ignored if it is undefined, allowing the creation of permanent invites with `max_age=0`.