### PR TITLE
Add support for VOICE_PRIORITY_SPEAKER

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1017,7 +1017,7 @@ DCP.editChannelPermissions = function(input, callback) { //Will shrink this up l
 	permissions = channel.permissions[pType][ID] || { allow: 0, deny: 0 };
 	allowed_values = [0, 4, 28, 29];
 	if (channel.type === 'text' || channel.type == 0 || channel.type == 4) allowed_values = allowed_values.concat([6, 10, 11, 12, 13, 14, 15, 16, 17, 18]);
-	if (channel.type === 'voice' || channel.type == 2 || channel.type == 4) allowed_values = allowed_values.concat([10, 20, 21, 22, 23, 24, 25]);
+	if (channel.type === 'voice' || channel.type == 2 || channel.type == 4) allowed_values = allowed_values.concat([8, 10, 20, 21, 22, 23, 24, 25]);
 
 	//Take care of allow first
 	if (type(input.allow) === 'array') {
@@ -2762,6 +2762,7 @@ Discord.Permissions = {
 	GENERAL_MANAGE_GUILD: 5,
 	TEXT_ADD_REACTIONS: 6,
 	GENERAL_AUDIT_LOG: 7,
+	VOICE_PRIORITY_SPEAKER: 8,
 	TEXT_READ_MESSAGES: 10, // compatibility with existing bots
 	GENERAL_VIEW_CHANNEL: 10, // writing a new bot? use this
 	TEXT_SEND_MESSAGES: 11,


### PR DESCRIPTION
Pretty simple. The permissions bit for priority speaker is 256, so I inserted 8 into Discord.Permissions and allowed_values.