### PR TITLE
Create DMRecipient object to describe the recipient of a DMChannel

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -407,10 +407,17 @@ declare namespace Discord {
   }
 
   export class DMChannel extends Resource {
-    recipient: Object;
+    recipient: DMRecipient;
     last_message_id: string;
     id: string;
   }
+
+   export class DMRecipient extends Resource {
+     username: string;
+     id: string;
+     discriminator: string;
+     avatar: string;
+   }
 
   export class User extends Resource {
     username: string;


### PR DESCRIPTION
I noticed that `DMChannel.recipient` was defined as a plain `Object` so this PR creates a class describing the object using string properties.